### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/pexpect-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/pexpect-feedstock)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/pexpect-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/pexpect-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/pexpect-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/pexpect-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/pexpect-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/pexpect-feedstock/branch/master)
 
@@ -83,12 +83,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pexpect/ba
 Updating pexpect-feedstock
 ==========================
 
-If you would like to improve the pexpect recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the pexpect recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/pexpect-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.2.0" %}
+{% set version = "4.2.1" %}
 
 package:
   name: pexpect
@@ -6,11 +6,11 @@ package:
 
 source:
   fn: pexpect-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/p/pexpect/pexpect-{{ version }}.tar.gz
-  md5: 8071ec5df0f3d515daedafad672d1632
+  url: https://github.com/pexpect/pexpect/archive/{{ version }}.tar.gz
+  sha256: f3e36792185a7b8b332a38846daa81d7e389688b7b63b9066d39c7f31a266a51
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install
 
 requirements:
@@ -27,7 +27,7 @@ test:
 about:
   home: http://pexpect.sourceforge.net/
   license: ISC
-  summary: Pexpect makes Python a better tool for controlling other applications.
+  summary: 'Pexpect makes Python a better tool for controlling other applications.'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
```
History
=======

Releases
--------

Version 4.2.1

* Fix to allow running ``env`` in replwrap-ed bash.
* Raise more informative exception from pxssh if it fails to connect.
* Change ``passmass`` example to not log passwords entered.

Version 4.2

* Change: When an ``env`` parameter is specified to the :class:`~.spawn` or
  :class:`~.run` family of calls containing a value for ``PATH``, its value is
  used to discover the target executable from a relative path, rather than the
  current process's environment ``PATH``.  This mirrors the behavior of
  :func:`subprocess.Popen` in the standard library (:ghissue:`348`).

* Regression: Re-introduce capability for :meth:`read_nonblocking` in class
  :class:`fdspawn` as previously supported in version 3.3 (:ghissue:`359`).
```